### PR TITLE
Fix metaDescription

### DIFF
--- a/utf8/dev2fun.multidomain/classes/general/SeoReplace.php
+++ b/utf8/dev2fun.multidomain/classes/general/SeoReplace.php
@@ -120,12 +120,12 @@ class SeoReplace
                     $replaceProp .= $titleJson['afterText'];
                 }
             }
-            $replaceProp = str_replace(
+            $replacePropFull = str_replace(
                 $matches[0],
                 $replaceProp,
                 $prop
             );
-            $APPLICATION->SetPageProperty('description', $replaceProp);
+            $APPLICATION->SetPageProperty('description', $replacePropFull);
             $content = str_replace(
                 htmlentities($matches[0]),
                 $replaceProp,

--- a/utf8/dev2fun.multidomain/classes/general/SeoReplace.php
+++ b/utf8/dev2fun.multidomain/classes/general/SeoReplace.php
@@ -85,8 +85,13 @@ class SeoReplace
                     $replaceTitle .= $titleJson['afterText'];
                 }
             }
-            $APPLICATION->SetPageProperty('title', $replaceTitle);
-            $APPLICATION->SetTitle($replaceTitle);
+            $replaceTitleFull = str_replace(
+                $matches[0],
+                $replaceTitle,
+                $prop
+            );
+            $APPLICATION->SetPageProperty('title', $replaceTitleFull);
+            $APPLICATION->SetTitle($replaceTitleFull);
             $content = str_replace(
                 $matches[0],
                 $replaceTitle,

--- a/win1251/dev2fun.multidomain/classes/general/SeoReplace.php
+++ b/win1251/dev2fun.multidomain/classes/general/SeoReplace.php
@@ -120,12 +120,12 @@ class SeoReplace
                     $replaceProp .= $titleJson['afterText'];
                 }
             }
-            $replaceProp = str_replace(
+            $replacePropFull = str_replace(
                 $matches[0],
                 $replaceProp,
                 $prop
             );
-            $APPLICATION->SetPageProperty('description', $replaceProp);
+            $APPLICATION->SetPageProperty('description', $replacePropFull);
             $content = str_replace(
                 htmlentities($matches[0]),
                 $replaceProp,

--- a/win1251/dev2fun.multidomain/classes/general/SeoReplace.php
+++ b/win1251/dev2fun.multidomain/classes/general/SeoReplace.php
@@ -85,8 +85,13 @@ class SeoReplace
                     $replaceTitle .= $titleJson['afterText'];
                 }
             }
-            $APPLICATION->SetPageProperty('title', $replaceTitle);
-            $APPLICATION->SetTitle($replaceTitle);
+            $replaceTitleFull = str_replace(
+                $matches[0],
+                $replaceTitle,
+                $prop
+            );
+            $APPLICATION->SetPageProperty('title', $replaceTitleFull);
+            $APPLICATION->SetTitle($replaceTitleFull);
             $content = str_replace(
                 $matches[0],
                 $replaceTitle,


### PR DESCRIPTION
При использовании шаблона metaDescription происходит двойная подстановка значения в шаблон и выводится неверный текст.

Например, поле UF_NAME текущего домена имеет значение "Параметр":
![image](https://github.com/darkfriend/dev2fun.multidomain/assets/122102646/99a478d2-72c2-4bda-80d4-52d91aa9d3fa)
Если в шаблоне для мета-тега description написать какой-либо текст, а в середину вставить шаблон {=multiDescription}:
![image](https://github.com/darkfriend/dev2fun.multidomain/assets/122102646/ebbe4bc4-c010-45d2-b010-61962c547744)
то в финальном HTML введенный текст задвоится:
![image](https://github.com/darkfriend/dev2fun.multidomain/assets/122102646/f91be9e5-7b8a-435e-b341-44919594b346)

Предлагаемые изменения устраняют эту ошибку.


Второй коммит в данном PR исправляет неточность в работе метода `SeoReplace::replaceTitle()`.

При установке шаблона для мета-тега title следующего значения:
![image](https://github.com/darkfriend/dev2fun.multidomain/assets/122102646/428be92c-74b9-4874-ad93-bfa8d6e71cb2)
происходит корректная его подстановка в финальный HTML-код:
![image](https://github.com/darkfriend/dev2fun.multidomain/assets/122102646/6bc8ecce-9177-4336-8270-a04a48c0b999)

Однако перед этим происходит установка свойств объекта `$APPLICATION` неполным текстом. Подставляется только значение самого шаблона {=multiTitle}:
![image](https://github.com/darkfriend/dev2fun.multidomain/assets/122102646/dd93641e-934b-4e29-91f9-8ea9a065b954)

Хотя в моем случае это не сказалось на финальном значении мета-тега title, полагаю, будет более надежно передавать объекту `$APPLICATION` корректные значения.